### PR TITLE
Cleaup bazel mpact-sim project usage

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,11 +42,3 @@ mpact_sim_repos()
 load("@com_google_mpact-sim//:deps.bzl", "mpact_sim_deps")
 
 mpact_sim_deps()
-
-# Google re2
-http_archive(
-    name = "com_google_re2",
-    sha256 = "7a9a4824958586980926a300b4717202485c4b4115ac031822e29aa4ef207e48",
-    strip_prefix = "re2-2023-03-01",
-    urls = ["https://github.com/google/re2/archive/refs/tags/2023-03-01.tar.gz"],
-)

--- a/riscv/BUILD
+++ b/riscv/BUILD
@@ -508,7 +508,7 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_mpact-sim//mpact/sim/generic:core_debug_interface",
         "@com_google_mpact-sim//mpact/sim/util/program_loader:elf_loader",
-        "@com_google_re2//:re2",
+        "@com_googlesource_code_re2//:re2",
     ],
 )
 


### PR DESCRIPTION
* Use the canonical name `com_googlesource_code_re2` to refer the re2
  project.

* Cleanup WORKSPACE. It should only depend on the dependency repo from
  MPACT-sim