### PR TITLE
Remove riscv/ prefix from bin_fmt and isa includes

### DIFF
--- a/riscv/riscv32gzb.bin_fmt
+++ b/riscv/riscv32gzb.bin_fmt
@@ -24,5 +24,5 @@ decoder RiscV32GZB {
   RiscV32GZBInst16 = {RiscVCInst16};
 }
 
-#include "riscv/riscv32g.bin_fmt"
-#include "riscv/riscv32zb.bin_fmt"
+#include "riscv32g.bin_fmt"
+#include "riscv32zb.bin_fmt"

--- a/riscv/riscv32gzb.isa
+++ b/riscv/riscv32gzb.isa
@@ -19,8 +19,8 @@ isa RiscV32GZB {
   }
 }
 
-#include "riscv/riscv32g.isa"
-#include "riscv/riscv32zb.isa"
+#include "riscv32g.isa"
+#include "riscv32zb.isa"
 
 slot riscv32gzb : riscv32g, riscv32_zba, riscv32_zbb, riscv32_zbb_imm,
                   riscv32_zbc, riscv32_zbs, riscv32_zbs_imm {

--- a/riscv/riscv32v.bin_fmt
+++ b/riscv/riscv32v.bin_fmt
@@ -37,6 +37,6 @@ decoder RiscV32GVZB {
   // Keep this separate (different base format).
   RiscVCInst16;
 }
-#include "riscv/riscv32zb.bin_fmt"
-#include "riscv/riscv32g.bin_fmt"
-#include "riscv/riscv_vector.bin_fmt"
+#include "riscv32zb.bin_fmt"
+#include "riscv32g.bin_fmt"
+#include "riscv_vector.bin_fmt"

--- a/riscv/riscv32v.isa
+++ b/riscv/riscv32v.isa
@@ -29,8 +29,8 @@ isa RiscV32GVZB {
   slots { riscv32gvzb; }
 }
 
-#include "riscv/riscv32gzb.isa"
-#include "riscv/riscv_vector.isa"
+#include "riscv32gzb.isa"
+#include "riscv_vector.isa"
 
 slot riscv32gv : riscv32g, riscv_vector {
   default size = 4;

--- a/riscv/riscv64gzb.bin_fmt
+++ b/riscv/riscv64gzb.bin_fmt
@@ -25,6 +25,6 @@ decoder RiscV64GZB {
   RiscV64GZBInst16 = {RiscVCInst16};
 }
 
-#include "riscv/riscv64g.bin_fmt"
-#include "riscv/riscv64zb.bin_fmt"
-#include "riscv/riscv32zb.bin_fmt"
+#include "riscv64g.bin_fmt"
+#include "riscv64zb.bin_fmt"
+#include "riscv32zb.bin_fmt"

--- a/riscv/riscv64gzb.isa
+++ b/riscv/riscv64gzb.isa
@@ -19,8 +19,8 @@ isa RiscV64GZB {
   }
 }
 
-#include "riscv/riscv64g.isa"
-#include "riscv/riscv64zb.isa"
+#include "riscv64g.isa"
+#include "riscv64zb.isa"
 
 slot riscv64gzb : riscv64g, riscv64_zba , riscv64_zbb, riscv64_zbb_imm,
                   riscv64_zbc, riscv64_zbs, riscv64_zbs_imm {

--- a/riscv/riscv64v.bin_fmt
+++ b/riscv/riscv64v.bin_fmt
@@ -39,7 +39,7 @@ decoder RiscV64GVZB {
   RiscVCInst16;
 }
 
-#include "riscv/riscv32zb.bin_fmt"
-#include "riscv/riscv64g.bin_fmt"
-#include "riscv/riscv64zb.bin_fmt"
-#include "riscv/riscv_vector.bin_fmt"
+#include "riscv32zb.bin_fmt"
+#include "riscv64g.bin_fmt"
+#include "riscv64zb.bin_fmt"
+#include "riscv_vector.bin_fmt"

--- a/riscv/riscv64v.isa
+++ b/riscv/riscv64v.isa
@@ -29,8 +29,8 @@ isa RiscV64GVZB {
   slots { riscv64gvzb; }
 }
 
-#include "riscv/riscv64gzb.isa"
-#include "riscv/riscv_vector.isa"
+#include "riscv64gzb.isa"
+#include "riscv_vector.isa"
 
 // This adds vector instructions.
 slot riscv64gv : riscv64g, riscv_vector {

--- a/riscv/riscv64zb.isa
+++ b/riscv/riscv64zb.isa
@@ -19,7 +19,7 @@ includes {
   #include "riscv/riscv_bitmanip_instructions.h"
 }
 
-#include "riscv/riscv32zb.isa"
+#include "riscv32zb.isa"
 
 disasm widths = {-18};
 

--- a/riscv/riscv_zvbb.bin_fmt
+++ b/riscv/riscv_zvbb.bin_fmt
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "riscv/riscv32g.bin_fmt"
-#include "riscv/riscv_vector.bin_fmt"
+#include "riscv32g.bin_fmt"
+#include "riscv_vector.bin_fmt"
 
 decoder ZVBB {
   namespace mpact::sim::riscv::zvbb;

--- a/riscv/riscv_zvbb.isa
+++ b/riscv/riscv_zvbb.isa
@@ -25,7 +25,7 @@ isa ZVBB {
 // First disasm field is 18 char wide and left justified.
 disasm widths = {-18};
 
-#include "riscv/riscv_vector.isa"
+#include "riscv_vector.isa"
 
 slot riscv_zvkb {
   includes {

--- a/riscv/rvm23.bin_fmt
+++ b/riscv/rvm23.bin_fmt
@@ -46,11 +46,11 @@ decoder RVM23 {
   };
 }
 
-#include "riscv/riscv32g.bin_fmt"
-#include "riscv/riscv32zb.bin_fmt"
-#include "riscv/riscv_zc.bin_fmt"
-#include "riscv/riscv_zhintpause.bin_fmt"
-#include "riscv/riscv_zicbop.bin_fmt"
-#include "riscv/riscv_zicond.bin_fmt"
-#include "riscv/riscv_zihintntl.bin_fmt"
-#include "riscv/riscv_zimop.bin_fmt"
+#include "riscv32g.bin_fmt"
+#include "riscv32zb.bin_fmt"
+#include "riscv_zc.bin_fmt"
+#include "riscv_zhintpause.bin_fmt"
+#include "riscv_zicbop.bin_fmt"
+#include "riscv_zicond.bin_fmt"
+#include "riscv_zihintntl.bin_fmt"
+#include "riscv_zimop.bin_fmt"

--- a/riscv/rvm23.isa
+++ b/riscv/rvm23.isa
@@ -19,15 +19,15 @@ isa RVM23 {
   }
 }
 
-#include "riscv/riscv32g.isa"
-#include "riscv/riscv32zb.isa"
-#include "riscv/riscv_vector.isa"
-#include "riscv/riscv_zc.isa"
-#include "riscv/riscv_zicbop.isa"
-#include "riscv/riscv_zicond.isa"
-#include "riscv/riscv_zimop.isa"
-#include "riscv/riscv_zhintpause.isa"
-#include "riscv/riscv_zihintntl.isa"
+#include "riscv32g.isa"
+#include "riscv32zb.isa"
+#include "riscv_vector.isa"
+#include "riscv_zc.isa"
+#include "riscv_zicbop.isa"
+#include "riscv_zicond.isa"
+#include "riscv_zimop.isa"
+#include "riscv_zhintpause.isa"
+#include "riscv_zihintntl.isa"
 
 slot rvm23 :
   riscv32i,


### PR DESCRIPTION
bin_fmt and isa includes used to have paths relative from the repository root, but they are not reliable as mpact_isa_decoder() and mpact_bin_fmt_decoder() uses a different directory as their working when the repository containing the source files is nested.

mpact-sim includes files in the directory of the source file since commit d958141f3e6f8dfbdc79e35a9beabaea490e479c so remove riscv/ prefix from paths to make them relative from the source directory. This also makes these paths more concise too.